### PR TITLE
Add RISC-V time retrieval in timeStamp.cpp

### DIFF
--- a/src/utils/timeStamp.cpp
+++ b/src/utils/timeStamp.cpp
@@ -40,6 +40,10 @@ static uint64_t rdtsc()
     asm volatile("mrs %0, cntvct_el0" : "=r" (val));
 
     return val;
+#elif defined(__riscv) && __riscv_xlen == 64
+	uint64_t current_time;
+	asm volatile ("rdtime %0" : "=r"(current_time));
+	return current_time;
 #else
 	return __rdtsc();
 #endif


### PR DESCRIPTION
# description
The timestamp.cpp file uses the x86-specific CPU instruction __rdtsc (Read Time-Stamp Counter). This instruction is used to obtain the CPU's high-precision cycle counter. It does not exist in non-x86 architecture (RISC-V) compilation environments, causing compilation failure. 
# environment
* version fceux 2.6.6
* Platform: RISC-V 64 bit
# patch
When choosing a replacement for rdtsc on RISC-V, I initially considered rdcycle and rdtime. Although rdcycle is closer in functionality to the original intention of rdtsc (measuring CPU workload), we chose to use rdtime based on the latest Linux kernel developments. https://gitlab.com/gromacs/gromacs/-/merge_requests/4040/diffs?commit_id=9124df970d1109fa672bc4f1ebba941517955763 The rdcycle instruction is being converted to a privileged instruction and will not be directly usable from user space in the future.